### PR TITLE
 Add BadMessageManager and ban bad senders automatically

### DIFF
--- a/ClubDoorman/BadMessageManager.cs
+++ b/ClubDoorman/BadMessageManager.cs
@@ -13,6 +13,10 @@ public class BadMessageManager
 
     public async ValueTask MarkAsBad(string message)
     {
+		if string.IsNullOrEmpty(message)
+		{
+			return;
+		}
         var hash = ComputeHash(message);
         if (_bad.Add(hash))
         {

--- a/ClubDoorman/BadMessageManager.cs
+++ b/ClubDoorman/BadMessageManager.cs
@@ -1,0 +1,33 @@
+﻿using System.Security.Cryptography;
+using System.Text;
+
+namespace ClubDoorman;
+
+public class BadMessageManager
+{
+    private const string Path = "data/bad-messages.txt";
+    private readonly SemaphoreSlim _semaphore = new(1);
+    private readonly HashSet<string> _bad = File.ReadAllLines(Path).ToHashSet();
+
+    public bool Bad(string message) => _bad.Contains(ComputeHash(message));
+
+    public async ValueTask MarkAsBad(string message)
+    {
+        var hash = ComputeHash(message);
+        if (_bad.Add(hash))
+        {
+            using var token = await SemaphoreHelper.AwaitAsync(_semaphore);
+            await File.AppendAllLinesAsync(Path, [hash]);
+        }
+    }
+
+    private static string ComputeHash(string message)
+    {
+        var bytes = Encoding.UTF8.GetBytes(message);
+        using (var hasher = SHA512.Create())
+        {
+            var hashBytes = hasher.ComputeHash(bytes);
+            return Convert.ToBase64String(hashBytes);
+        }
+    }
+}

--- a/ClubDoorman/Program.cs
+++ b/ClubDoorman/Program.cs
@@ -24,6 +24,7 @@ public class Program
                 services.AddHostedService<Worker>();
                 services.AddSingleton<SpamHamClassifier>();
                 services.AddSingleton<UserManager>();
+                services.AddSingleton<BadMessageManager>();
             })
             .Build();
 

--- a/ClubDoorman/Worker.cs
+++ b/ClubDoorman/Worker.cs
@@ -602,7 +602,7 @@ public class Worker(ILogger<Worker> logger, SpamHamClassifier classifier, UserMa
 
     private async Task AdminChatMessage(Message message)
     {
-        if (message is { ReplyToMessage: { } replyToMessage, Text: "/spam" or "/ham" or "/check" or "/bad" })
+        if (message is { ReplyToMessage: { } replyToMessage, Text: "/spam" or "/ham" or "/check" or "/alwaysban" })
         {
             if (replyToMessage.From?.Id == _me.Id && replyToMessage.ForwardFrom == null && replyToMessage.ForwardSenderName == null)
             {
@@ -645,8 +645,13 @@ public class Worker(ILogger<Worker> logger, SpamHamClassifier classifier, UserMa
                         );
                         await badMessageManager.MarkAsBad(replyToMessage.Text ?? replyToMessage.Caption ?? string.Empty);
                         break;
-                    case "/bad":
+                    case "/alwaysban":
                         await badMessageManager.MarkAsBad(replyToMessage.Text ?? replyToMessage.Caption ?? string.Empty);
+						await _bot.SendTextMessageAsync(
+							message.Chat.Id,
+							"Теперь за такие сообщения будем автоматически банить",
+							replyToMessageId: replyToMessage.MessageId
+						);
                         break;
                     case "/ham":
                         await classifier.AddHam(replyToMessage.Text ?? replyToMessage.Caption ?? string.Empty);

--- a/ClubDoorman/Worker.cs
+++ b/ClubDoorman/Worker.cs
@@ -9,7 +9,7 @@ using Telegram.Bot.Types.ReplyMarkups;
 
 namespace ClubDoorman;
 
-public class Worker(ILogger<Worker> logger, SpamHamClassifier classifier, UserManager userManager) : BackgroundService
+public class Worker(ILogger<Worker> logger, SpamHamClassifier classifier, UserManager userManager, BadMessageManager badMessageManager) : BackgroundService
 {
     private record CaptchaInfo(
         long ChatId,
@@ -177,6 +177,23 @@ public class Worker(ILogger<Worker> logger, SpamHamClassifier classifier, UserMa
         {
             logger.LogDebug("Empty text/caption");
             await DontDeleteButReportMessage(message, user, stoppingToken);
+            return;
+        }
+        if (badMessageManager.Bad(text))
+        {
+            try
+            {
+                await _bot.BanChatMemberAsync(message.Chat.Id, user.Id);
+                await _bot.DeleteMessageAsync(message.Chat, message.MessageId);
+                await _bot.SendTextMessageAsync(
+                    new ChatId(Config.AdminChatId),
+                    $"Автоматически забанили юзера {FullName(user.FirstName, user.LastName)} tg://user?id={user.Id} в чате {message.Chat.Title} (точно плохое сообщение)"
+                );
+            }
+            catch (Exception e)
+            {
+                logger.LogWarning(e, "Unable to ban");
+            }
             return;
         }
         if (SimpleFilters.TooManyEmojis(text))
@@ -585,7 +602,7 @@ public class Worker(ILogger<Worker> logger, SpamHamClassifier classifier, UserMa
 
     private async Task AdminChatMessage(Message message)
     {
-        if (message is { ReplyToMessage: { } replyToMessage, Text: "/spam" or "/ham" or "/check" })
+        if (message is { ReplyToMessage: { } replyToMessage, Text: "/spam" or "/ham" or "/check" or "/bad" })
         {
             if (replyToMessage.From?.Id == _me.Id && replyToMessage.ForwardFrom == null && replyToMessage.ForwardSenderName == null)
             {
@@ -626,6 +643,10 @@ public class Worker(ILogger<Worker> logger, SpamHamClassifier classifier, UserMa
                             "Сообщение добавлено как пример спама в датасет",
                             replyToMessageId: replyToMessage.MessageId
                         );
+                        await badMessageManager.MarkAsBad(replyToMessage.Text ?? replyToMessage.Caption ?? string.Empty);
+                        break;
+                    case "/bad":
+                        await badMessageManager.MarkAsBad(replyToMessage.Text ?? replyToMessage.Caption ?? string.Empty);
                         break;
                     case "/ham":
                         await classifier.AddHam(replyToMessage.Text ?? replyToMessage.Caption ?? string.Empty);


### PR DESCRIPTION
Store hashes (SHA512 -> Base64) in `bad-messages.txt`. If any message had a copy in that file, ban the sender without any questions.

Add more bad message to database, marking "/spam" messages or using "/alwaysblock" command.